### PR TITLE
update watchdog timeout and add nuvoton openbic flash shell

### DIFF
--- a/common/hal/nuvoton/hal_wdt.h
+++ b/common/hal/nuvoton/hal_wdt.h
@@ -18,8 +18,8 @@
 #define HAL_WDT_H
 
 #define WDT_DEVICE_NAME "TWD_0"
-#define WDT_TIMEOUT (8 * 1000) // 8s
-#define WDT_FEED_DELAY_MS (4 * 1000) // 4s
+#define WDT_TIMEOUT (15 * 1000) // 15s
+#define WDT_FEED_DELAY_MS (10 * 1000) // 10s
 
 #define WDT_THREAD_STACK_SIZE 256
 

--- a/common/shell/commands/nuvoton/flash_shell.c
+++ b/common/shell/commands/nuvoton/flash_shell.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flash_shell.h"
+#include <devicetree.h>
+#include <device.h>
+#include <stdio.h>
+#include "libutil.h"
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(flash_shell);
+
+
+/*
+    Command FLASH
+*/
+void cmd_flash_re_init(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 2) {
+		shell_warn(shell, "Help: platform flash re_init <spi_device>");
+		return;
+	}
+
+	const struct device *flash_dev;
+	flash_dev = device_get_binding(argv[1]);
+
+	if (!flash_dev) {
+		shell_error(shell, "Can't find any binding device with label %s", argv[1]);
+	}
+
+	if (spi_nor_re_init(flash_dev)) {
+		shell_error(shell, "%s re-init failed!", argv[1]);
+		return;
+	}
+
+	shell_print(shell, "%s re-init success!", argv[1]);
+	return;
+}
+
+void cmd_flash_sfdp_read(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc < 2 || argc > 4) {
+		shell_warn(
+			shell,
+			"Help: platform flash sfdp_read <spi_device> <offset(optional, default 0h)> <read_bytes(optional, default_max 256)>");
+		return;
+	}
+
+	int read_bytes = MAX_SFDP_BUFF_SIZE;
+	int offset = 0;
+	if (argc == 4) {
+		offset = strtol(argv[2], NULL, 16);
+		read_bytes = strtol(argv[3], NULL, 10);
+		if (read_bytes > MAX_SFDP_BUFF_SIZE)
+			read_bytes = MAX_SFDP_BUFF_SIZE;
+	} else if (argc == 3) {
+		offset = strtol(argv[2], NULL, 10);
+	}
+
+	const struct device *flash_dev;
+	flash_dev = device_get_binding(argv[1]);
+
+	if (!flash_dev) {
+		shell_error(shell, "Can't find any binding device with label %s", argv[1]);
+	}
+
+	if (!device_is_ready(flash_dev)) {
+		shell_error(shell, "%s: device not ready", flash_dev->name);
+		return;
+	}
+
+	uint8_t *raw = malloc(read_bytes * sizeof(uint8_t));
+	SHELL_CHECK_NULL_ARG(raw);
+	memset(raw, 0, read_bytes);
+
+	int ret = flash_sfdp_read(flash_dev, offset, raw, read_bytes);
+	if (ret) {
+		shell_error(shell, "Failed to read flash sfdp with ret: %d", ret);
+		goto exit;
+	}
+
+	printf("sfdp raw read from ofst %xh with %d bytes:", offset, read_bytes);
+	if ((offset % 4)) {
+		printf("\n[%-3x] ", 0);
+		for (int i = 0; i < (offset % 4); i++) {
+			printf("   ");
+		}
+	}
+	for (int i = 0; i < read_bytes; i++) {
+		if (!((offset + i) % 4)) {
+			printf("\n[%-3x] ", (offset + i));
+		}
+		printf("%.2x ", raw[i]);
+	}
+	printf("\n");
+
+exit:
+	SAFE_FREE(raw);
+	return;
+}
+
+/* Flash sub command */
+void device_spi_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_lookup(idx, SPI_DEVICE_PREFIX);
+
+	if (entry == NULL) {
+		LOG_ERR("entry is NULL");
+		return;
+	}
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}

--- a/common/shell/commands/nuvoton/flash_shell.h
+++ b/common/shell/commands/nuvoton/flash_shell.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLASH_SHELL_H
+#define FLASH_SHELL_H
+
+#include <stdlib.h>
+#include <shell/shell.h>
+#include <drivers/spi_nor.h>
+#include <drivers/flash.h>
+
+#define SPI_DEVICE_PREFIX "spi"
+#define MAX_SFDP_BUFF_SIZE 256
+
+void cmd_flash_re_init(const struct shell *shell, size_t argc, char **argv);
+void cmd_flash_sfdp_read(const struct shell *shell, size_t argc, char **argv);
+void device_spi_name_get(size_t idx, struct shell_static_entry *entry);
+
+SHELL_DYNAMIC_CMD_CREATE(spi_device_name, device_spi_name_get);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_flash_cmds,
+			       SHELL_CMD(re_init, &spi_device_name, "Re-init spi config",
+					 cmd_flash_re_init),
+			       SHELL_CMD(sfpd_read, &spi_device_name, "SFPD read",
+					 cmd_flash_sfdp_read),
+			       SHELL_SUBCMD_SET_END);
+
+#endif

--- a/common/shell/commands/nuvoton/shell_platform.c
+++ b/common/shell/commands/nuvoton/shell_platform.c
@@ -16,11 +16,13 @@
 
 #include "commands/gpio_shell.h"
 #include "commands/info_shell.h"
+#include "commands/flash_shell.h"
 
 /* MAIN command */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_platform_cmds, SHELL_CMD(info, NULL, "Platform info.", cmd_info_print),
 	SHELL_CMD(gpio, &sub_gpio_cmds, "GPIO relative command.", NULL),
+	SHELL_CMD(flash, &sub_flash_cmds, "FLASH(spi) relative command.", NULL),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(platform, &sub_platform_cmds, "Platform commands", NULL);


### PR DESCRIPTION
yv35-npcm-test: update watchdog timeout and feed intervel
-> update watchdog timeout from 8 to 15 (match openbic framework)
-> update watchdog feed interval from 4 to 10 (match openbic framework)

yv35-npcm-test: add nuvoton flash shell test items
-> add openbic flash shell for nuvoton platform (support re_init and sfpd_read)