### PR TITLE
yv35-npcm-test: implement API to get reset reason

### DIFF
--- a/common/lib/util_sys.c
+++ b/common/lib/util_sys.c
@@ -145,6 +145,11 @@ __weak int pal_get_set_add_debug_sel_mode_status(uint8_t options, uint8_t *statu
 	return -1;
 }
 
+__weak uint8_t pal_get_reset_reason(void)
+{
+	return RESET_REASON_INVALID;
+}
+
 /* The byte-2 of ME response for "Get Self-Test Result" command */
 enum GET_SELF_TEST_RESULT_RESPONSE {
 	NO_ERROR = 0x55,

--- a/common/lib/util_sys.h
+++ b/common/lib/util_sys.h
@@ -23,6 +23,11 @@
 
 #define INTEL_IANA 0x000157
 
+#define RESET_REASON_POWERUP            0x0
+#define RESET_REASON_WATCHDOG           0x1
+#define RESET_REASON_SWRST              0x2
+#define RESET_REASON_INVALID            0xff
+
 enum CC_12V_CYCLE_SLOT {
 	SUCCESS_12V_CYCLE_SLOT,
 	NOT_SUPPORT_12V_CYCLE_SLOT,
@@ -93,5 +98,7 @@ void set_sys_ready_pin(uint8_t ready_gpio_name);
 uint8_t get_system_class();
 
 int pal_get_set_add_debug_sel_mode_status(uint8_t options, uint8_t *status);
+
+uint8_t pal_get_reset_reason(void);
 
 #endif

--- a/common/service/main.c
+++ b/common/service/main.c
@@ -29,6 +29,7 @@
 #include "usb.h"
 #include <logging/log.h>
 #include <logging/log_ctrl.h>
+#include <util_sys.h>
 
 __weak void pal_pre_init()
 {
@@ -54,6 +55,8 @@ void main(void)
 {
 	printf("Hello, welcome to %s %s %x%x.%x.%x\n", PLATFORM_NAME, PROJECT_NAME, BIC_FW_YEAR_MSB,
 	       BIC_FW_YEAR_LSB, BIC_FW_WEEK, BIC_FW_VER);
+
+	printf("Reset Reason: %d\n", pal_get_reset_reason());
 
 	wdt_init();
 	util_init_timer();

--- a/meta-facebook/yv35-npcm-test/src/lib/plat_sys.c
+++ b/meta-facebook/yv35-npcm-test/src/lib/plat_sys.c
@@ -15,11 +15,38 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <soc.h>
 #include "hal_wdt.h"
+#include "util_sys.h"
 #include <drivers/watchdog.h>
 
 /* give a chance since we may need upgrade fw before reboot system */
 #define REBOOT_WDT_TIMEOUT (30 * 1000) /* 30s */
+
+uint8_t pal_get_reset_reason(void)
+{
+	enum npcm4xx_reset_reason reset_reason;
+	uint8_t reason_value = RESET_REASON_INVALID;
+
+	reset_reason = npcm4xx_get_reset_reason();
+
+	switch(reset_reason) {
+		case NPCM4XX_RESET_REASON_VCC_POWERUP:
+			reason_value = RESET_REASON_POWERUP;
+			break;
+		case NPCM4XX_RESET_REASON_WDT_RST:
+			reason_value = RESET_REASON_WATCHDOG;
+			break;
+		case NPCM4XX_RESET_REASON_DEBUGGER_RST:
+			reason_value = RESET_REASON_SWRST;
+			break;
+		default:
+			reason_value = RESET_REASON_INVALID;
+			break;
+	}
+
+	return reason_value;
+}
 
 #ifdef CONFIG_XIP
 static void pal_wdt_reset(void)


### PR DESCRIPTION
implement API to get reset reason.

now support powerup/wdt/swreset type.