### PR TITLE
yv35-npcm-test: use i2c2a for ipmb

### DIFF
--- a/meta-facebook/yv35-npcm-test/boards/npcm400f_evb.overlay
+++ b/meta-facebook/yv35-npcm-test/boards/npcm400f_evb.overlay
@@ -2,7 +2,7 @@
        status = "okay";
 };
 
-&i2c3a {
+&i2c2a {
 	ipmb1: ipmb@11 {
 		compatible = "zephyr,i2c-ipmb";
 		reg = <0x11>;


### PR DESCRIPTION
Use i2c2a for ipmb