### PR TITLE
common: hal: nuvoton: change to use master_dev in i3c_dev_desc

### DIFF
--- a/common/hal/nuvoton/hal_i3c.c
+++ b/common/hal/nuvoton/hal_i3c.c
@@ -44,7 +44,7 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
 
 	for (i = 0; i < I3C_MAX_NUM; i++) {
 		desc = &i3c_desc_table[i];
-		if ((desc->bus == dev) && (desc->info.dynamic_addr == desc_addr)) {
+		if ((desc->master_dev == dev) && (desc->info.dynamic_addr == desc_addr)) {
 			return desc;
 		}
 	}


### PR DESCRIPTION
Aspeed change to use "bus" to represent the bus controller in i3c_dev_desc, but openbic expect use old "master_dev" definition.