### PR TITLE
yv35-npcm-test: support i3c master mode

### DIFF
--- a/common/hal/nuvoton/hal_i3c.c
+++ b/common/hal/nuvoton/hal_i3c.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(hal_i3c);
 static const struct device *dev_i3c[I3C_MAX_NUM];
 static const struct device *dev_i3c_smq[I3C_MAX_NUM];
 static struct i3c_dev_desc i3c_desc_table[I3C_MAX_NUM];
+static i3c_ibi_dev i3c_ibi_dev_table[I3C_MAX_NUM];
 static int i3c_desc_count = 0;
 static struct k_mutex mutex_write[I3C_MAX_NUM];
 static struct k_mutex mutex_read[I3C_MAX_NUM];
@@ -35,7 +36,8 @@ static struct k_mutex mutex_read[I3C_MAX_NUM];
 int i3c_slave_mqueue_read(const struct device *dev, uint8_t *dest, int budget);
 int i3c_slave_mqueue_write(const struct device *dev, uint8_t *src, int size);
 
-static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t desc_addr)
+static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t desc_addr,
+					       int *pos)
 {
 	CHECK_NULL_ARG_WITH_RETURN(dev, NULL);
 
@@ -45,6 +47,10 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
 	for (i = 0; i < I3C_MAX_NUM; i++) {
 		desc = &i3c_desc_table[i];
 		if ((desc->master_dev == dev) && (desc->info.dynamic_addr == desc_addr)) {
+			if (pos == NULL) {
+				return desc;
+			}
+			*pos = i;
 			return desc;
 		}
 	}
@@ -119,13 +125,19 @@ int i3c_attach(I3C_MSG *msg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
 
-	int ret = 0;
+	int ret = 0, pos = 0;
 	struct i3c_dev_desc *desc;
 
 	if (!dev_i3c[msg->bus]) {
 		LOG_ERR("Failed to attach address 0x%x due to undefined bus%u", msg->target_addr,
 			msg->bus);
 		return -ENODEV;
+	}
+
+	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, &pos);
+	if (desc != NULL) {
+		LOG_INF("addr 0x%x already attach", msg->target_addr);
+		return -ret;
 	}
 
 	desc = &i3c_desc_table[i3c_desc_count];
@@ -139,6 +151,39 @@ int i3c_attach(I3C_MSG *msg)
 	} else {
 		LOG_ERR("Failed to attach address 0x%x, ret: %d", msg->target_addr, ret);
 	}
+
+	return -ret;
+}
+
+int i3c_detach(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	int ret = 0, pos = 0, i;
+	struct i3c_dev_desc *desc;
+
+	if (!dev_i3c[msg->bus]) {
+		LOG_ERR("Failed to detach address 0x%x due to undefined bus%u", msg->target_addr,
+			msg->bus);
+		return -ENODEV;
+	}
+
+	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, &pos);
+	if (desc == NULL) {
+		LOG_ERR("Failed to detach address 0x%x due to unknown address", msg->target_addr);
+		return -ENODEV;
+	}
+
+	ret = i3c_master_detach_device(dev_i3c[msg->bus], desc);
+	if (ret != 0) {
+		LOG_ERR("Failed to detach address 0x%x, ret: %d", msg->target_addr, ret);
+		return -ret;
+	}
+
+	for (i = pos; i < i3c_desc_count; i++) {
+		i3c_desc_table[i] = i3c_desc_table[i + 1];
+	}
+	i3c_desc_count--;
 
 	return -ret;
 }
@@ -161,7 +206,7 @@ int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr)
 	ccc.id = ccc_id;
 	ccc.rnw = I3C_WRITE_CMD;
 	ccc.payload.data = &msg->data;
-	ccc.payload.length = 0;
+	ccc.payload.length = msg->tx_len;
 
 	ret = i3c_master_send_ccc(dev_i3c[msg->bus], &ccc);
 	if (ret != 0) {
@@ -182,11 +227,11 @@ int i3c_transfer(I3C_MSG *msg)
 		return -ENODEV;
 	}
 
-	int ret = 0;
+	int ret = 0, *pos = NULL;
 	struct i3c_dev_desc *desc;
 	struct i3c_priv_xfer xfer_data[I3C_MAX_BUFFER_COUNT];
 
-	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr);
+	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, pos);
 	if (desc == NULL) {
 		LOG_ERR("Failed to transfer messages to address 0x%x due to unknown address",
 			msg->target_addr);
@@ -219,7 +264,7 @@ int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm)
 		return -ENODEV;
 	}
 
-	int ret = 0;
+	int ret = 0, *pos = NULL;
 	struct i3c_dev_desc *desc;
 	uint8_t addr = (msg->data[1] << 8 | msg->data[0]) % 64;
 	uint8_t block_addr = (msg->data[1] << 8 | msg->data[0]) / 64;
@@ -232,7 +277,7 @@ int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm)
 	}
 	uint8_t offset[2] = { offset0, offset1 };
 
-	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr);
+	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, pos);
 	if (desc == NULL) {
 		LOG_ERR("Failed to transfer messages to address 0x%x due to unknown address",
 			msg->target_addr);
@@ -246,6 +291,48 @@ int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm)
 	}
 
 	return ret;
+}
+
+int i3c_controller_write(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	int *pos = NULL;
+	struct i3c_dev_desc *target;
+	target = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, pos);
+	if (target == NULL) {
+		LOG_ERR("Failed to write messages to address 0x%x due to unknown address",
+			msg->target_addr);
+		return -ENODEV;
+	}
+
+	struct i3c_priv_xfer xfer[1];
+
+	xfer[0].rnw = I3C_WRITE_CMD;
+	xfer[0].len = msg->tx_len;
+	xfer[0].data.out = &msg->data;
+
+	int ret = i3c_master_priv_xfer(target, xfer, 1);
+	if (ret != 0) {
+		LOG_ERR("Failed to write messages to bus 0x%d addr 0x%x, ret: %d", msg->bus,
+			msg->target_addr, ret);
+		return false;
+	}
+
+	return true;
+}
+
+int i3c_set_pid(I3C_MSG *msg, uint16_t slot_pid)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	int ret = i3c_set_pid_extra_info(dev_i3c[msg->bus], slot_pid);
+	if (ret != 0) {
+		LOG_ERR("Failed to set pid to bus 0x%d, ret: %d", msg->bus, ret);
+		return false;
+	}
+
+	return true;
 }
 
 void util_init_i3c(void)
@@ -307,4 +394,247 @@ void util_init_i3c(void)
 			LOG_ERR("Mutex %d init error.",i);
 		}
 	}
+}
+
+static int get_bus_id(struct i3c_dev_desc *desc)
+{
+	char i3c_dev_name[I3C_DEV_STR_LEN] = { 0 };
+	const char delim[2] = "_";
+	char *saveptr = NULL;
+	char *substr = NULL;
+	int bus_id;
+
+	strncpy(i3c_dev_name, desc->master_dev->name, I3C_DEV_STR_LEN);
+
+	substr = strtok_r(i3c_dev_name, delim, &saveptr);
+	substr = strtok_r(NULL, delim, &saveptr);
+
+	bus_id = atoi(substr);
+	if (bus_id > I3C_MAX_NUM) {
+		LOG_ERR("bus id out of range, bus = %d", bus_id);
+		return -1;
+	}
+
+	return bus_id;
+}
+
+static int find_dev_i3c_idx(struct i3c_dev_desc *desc)
+{
+	int bus_id = get_bus_id(desc);
+	if (bus_id < 0) {
+		return -1;
+	}
+
+	int i = 0;
+	struct i3c_dev_desc *desc_ptr = NULL;
+	for (i = 0; i < i3c_desc_count; i++) {
+		desc_ptr = &i3c_desc_table[i];
+
+		int table_bus_id = get_bus_id(desc_ptr);
+		if (table_bus_id < 0) {
+			return -1;
+		}
+
+		if ((table_bus_id == bus_id) &&
+		    (desc->info.dynamic_addr == desc_ptr->info.dynamic_addr)) {
+			return i;
+		}
+	}
+
+	LOG_ERR("Not found id in i3c table");
+
+	return -1;
+}
+
+static struct i3c_ibi_payload *ibi_write_requested(struct i3c_dev_desc *desc)
+{
+	int idx = find_dev_i3c_idx(desc);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+	i3c_ibi_dev_table[idx].i3c_payload.max_payload_size = I3C_MAX_DATA_SIZE;
+	i3c_ibi_dev_table[idx].i3c_payload.size = 0;
+	i3c_ibi_dev_table[idx].i3c_payload.buf = i3c_ibi_dev_table[idx].data_rx;
+
+	return &i3c_ibi_dev_table[idx].i3c_payload;
+}
+
+static void ibi_write_done(struct i3c_dev_desc *desc)
+{
+	int idx = find_dev_i3c_idx(desc);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+	k_sem_give(&i3c_ibi_dev_table[idx].ibi_complete);
+}
+
+static struct i3c_ibi_callbacks i3c_ibi_def_callbacks = {
+	.write_requested = ibi_write_requested,
+	.write_done = ibi_write_done,
+};
+
+int i3c_controller_ibi_init(I3C_MSG *msg)
+{
+	I3C_MSG i3c_msg = { 0 };
+
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		LOG_ERR("Failed to receive messages to address 0x%x due to undefined bus%u",
+			msg->target_addr, msg->bus);
+		return -ENODEV;
+	}
+
+	struct i3c_dev_desc *target;
+	target = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, NULL);
+	if (target == NULL) {
+		LOG_ERR("Failed to reveive messages to address 0x%x due to unknown address",
+			msg->target_addr);
+		return -ENODEV;
+	}
+
+	int ret = 0;
+
+	int idx = find_dev_i3c_idx(target);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+
+	k_sem_init(&i3c_ibi_dev_table[idx].ibi_complete, 0, 1);
+
+	ret = i3c_master_send_rstdaa(dev_i3c[msg->bus]);
+	if (ret) {
+		LOG_ERR("Failed to send rstdaa");
+	}
+
+	ret = i3c_master_send_rstdaa(dev_i3c[msg->bus]);
+	if (ret) {
+		LOG_ERR("Failed to 2nd send rstdaa");
+	}
+
+	ret = i3c_master_send_aasa(dev_i3c[msg->bus]);
+	if (ret) {
+		LOG_ERR("Failed to send aasa");
+	}
+
+	/* only support i3c spec 1.0, need set dasa to assign static addr to dynamic */
+	i3c_msg.bus = msg->bus;
+	i3c_msg.target_addr = msg->target_addr;
+	i3c_msg.data[0] = i3c_msg.target_addr << 1;
+	i3c_msg.tx_len = 1;
+
+	ret = i3c_brocast_ccc(&i3c_msg, I3C_CCC_SETDASA, i3c_msg.target_addr);
+	if (ret != 0) {
+		LOG_ERR("Failed to send dasa");
+	}
+
+	ret = i3c_master_send_getpid(dev_i3c[msg->bus], target->info.dynamic_addr,
+				     &target->info.pid);
+	if (ret) {
+		LOG_ERR("Failed to get pid");
+	}
+
+	ret = i3c_master_send_getbcr(dev_i3c[msg->bus], target->info.dynamic_addr,
+				     &target->info.bcr);
+	if (ret) {
+		LOG_ERR("Failed to get bcr");
+	}
+
+	ret = i3c_master_request_ibi(target, &i3c_ibi_def_callbacks);
+	if (ret != 0) {
+		LOG_ERR("Failed to request SIR, bus = %x, addr = %u", msg->target_addr, msg->bus);
+	}
+
+	ret = i3c_master_enable_ibi(target);
+	if (ret != 0) {
+		LOG_ERR("Failed to enable SIR, bus = %x, addr = %u", msg->target_addr, msg->bus);
+	}
+
+	return -ret;
+}
+
+int i3c_controller_ibi_read(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		LOG_ERR("Failed to receive messages to address 0x%x due to undefined bus%u",
+			msg->target_addr, msg->bus);
+		return -ENODEV;
+	}
+
+	struct i3c_dev_desc *target;
+	target = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, NULL);
+	if (target == NULL) {
+		LOG_ERR("Failed to reveive messages to address 0x%x due to unknown address",
+			msg->target_addr);
+		return -ENODEV;
+	}
+
+	int idx = find_dev_i3c_idx(target);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+
+	/* master device waits for the IBI from the target */
+	k_sem_take(&i3c_ibi_dev_table[idx].ibi_complete, K_FOREVER);
+
+	/* init the flag for the next loop */
+	k_sem_init(&i3c_ibi_dev_table[idx].ibi_complete, 0, 1);
+
+	int ret = 0;
+
+	/* check result: first byte (MDB) shall match the DT property mandatory-data-byte */
+	if (IS_MDB_PENDING_READ_NOTIFY(i3c_ibi_dev_table[idx].data_rx[0])) {
+		struct i3c_priv_xfer xfer;
+
+		/* initiate a private read transfer to read the pending data */
+		xfer.rnw = 1;
+		xfer.len = IBI_PAYLOAD_SIZE;
+		xfer.data.in = i3c_ibi_dev_table[idx].data_rx;
+		k_yield();
+		ret = i3c_master_priv_xfer(target, &xfer, 1);
+		if (ret) {
+			LOG_ERR("ibi read failed. ret = %d", ret);
+		}
+		msg->rx_len = xfer.len;
+		memcpy(msg->data, i3c_ibi_dev_table[idx].data_rx, IBI_PAYLOAD_SIZE);
+	}
+
+	return msg->rx_len;
+}
+
+int i3c_target_set_address(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		return -ENODEV;
+	}
+
+	int ret = i3c_slave_set_static_addr(dev_i3c[msg->bus], msg->target_addr);
+	if (ret != 0) {
+		LOG_ERR("Failed to set address 0x%x, ret: %d", msg->target_addr, ret);
+		return -1;
+	}
+
+	return 0;
+}
+
+int i3c_target_get_dynamic_address(I3C_MSG *msg, uint8_t *dynamic_addr)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+	CHECK_NULL_ARG_WITH_RETURN(dynamic_addr, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		return -ENODEV;
+	}
+
+	int ret = i3c_slave_get_dynamic_addr(dev_i3c[msg->bus], dynamic_addr);
+	if (ret != 0) {
+		LOG_ERR("Failed to get address for I3C bus: %x, ret: %d", msg->bus, ret);
+		return -1;
+	}
+
+	return 0;
 }

--- a/common/hal/nuvoton/hal_i3c.h
+++ b/common/hal/nuvoton/hal_i3c.h
@@ -93,6 +93,11 @@
 #define I3C_SMQ_SUCCESS 0
 #define I3C_MAX_BUFFER_COUNT 2
 
+#define IBI_PAYLOAD_SIZE 128
+
+#define I3C_DEV_STR_LEN 8
+#define I3C_BUS_STR_LEN 4
+
 enum I3C_WRITE_READ_CMD {
 	I3C_WRITE_CMD = 0,
 	I3C_READ_CMD,
@@ -102,16 +107,33 @@ typedef struct _I3C_MSG_ {
 	uint8_t bus;
 	uint8_t target_addr;
 	uint8_t tx_len;
-	uint8_t rx_len;
+	int rx_len;
 	uint8_t data[I3C_MAX_DATA_SIZE];
 } I3C_MSG;
+
+typedef struct _i3c_ibi_dev {
+	uint8_t data_rx[I3C_MAX_DATA_SIZE];
+	struct i3c_ibi_payload i3c_payload;
+	struct k_sem ibi_complete;
+} i3c_ibi_dev;
 
 void util_init_i3c(void);
 int i3c_smq_read(I3C_MSG *msg);
 int i3c_smq_write(I3C_MSG *msg);
+int i3c_slave_mqueue_read(const struct device *dev, uint8_t *dest, int budget);
+int i3c_slave_mqueue_write(const struct device *dev, uint8_t *src, int size);
+
 int i3c_attach(I3C_MSG *msg);
+int i3c_detach(I3C_MSG *msg);
 int i3c_transfer(I3C_MSG *msg);
 int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr);
 int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm);
+int i3c_set_pid(I3C_MSG *msg, uint16_t slot_pid);
+
+int i3c_controller_write(I3C_MSG *msg);
+int i3c_controller_ibi_init(I3C_MSG *msg);
+int i3c_controller_ibi_read(I3C_MSG *msg);
+int i3c_target_set_address(I3C_MSG *msg);
+int i3c_target_get_dynamic_address(I3C_MSG *msg, uint8_t *dynamic_addr);
 
 #endif

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -257,6 +257,7 @@ uint8_t mctp_bridge_msg(mctp *mctp_inst, uint8_t *buf, uint16_t len, mctp_ext_pa
 /* medium init/deinit */
 uint8_t mctp_smbus_init(mctp *mctp_inst, mctp_medium_conf medium_conf);
 uint8_t mctp_smbus_deinit(mctp *mctp_inst);
+uint8_t mctp_i3c_controller_init(mctp *mctp_instance, mctp_medium_conf medium_conf);
 uint8_t mctp_i3c_target_init(mctp *mctp_instance, mctp_medium_conf medium_conf);
 uint8_t mctp_i3c_deinit(mctp *mctp_instance);
 uint8_t mctp_serial_init(mctp *mctp_inst, mctp_medium_conf medium_conf);

--- a/common/service/mctp/mctp_i3c.c
+++ b/common/service/mctp/mctp_i3c.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "plat_def.h"
+#ifdef ENABLE_MCTP_I3C
 #include "mctp.h"
 
 #include <stdlib.h>
@@ -29,6 +31,98 @@ LOG_MODULE_REGISTER(mctp_i3c);
 #ifndef MCTP_I3C_PEC_ENABLE
 #define MCTP_I3C_PEC_ENABLE 0
 #endif
+
+static uint16_t mctp_i3c_read(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params *extra_data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(extra_data, MCTP_ERROR);
+
+	mctp *mctp_inst = (mctp *)mctp_p;
+	I3C_MSG i3c_msg = { 0 };
+
+	i3c_msg.bus = mctp_inst->medium_conf.i3c_conf.bus;
+	i3c_msg.target_addr = mctp_inst->medium_conf.i3c_conf.addr;
+
+	int ret = i3c_controller_ibi_read(&i3c_msg);
+
+	/** mctp rx keep polling, return length 0 directly if no data or invalid data **/
+	if (ret <= 0) {
+		return 0;
+	}
+
+	i3c_msg.rx_len = ret;
+	LOG_HEXDUMP_DBG(&i3c_msg.data[0], i3c_msg.rx_len, "mctp_i3c_read_smq msg dump");
+
+	if (MCTP_I3C_PEC_ENABLE) {
+		uint8_t pec = 0x0, dynamic_addr = 0x0;
+
+		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
+		dynamic_addr = i3c_msg.target_addr << 1 | 1;
+		pec = crc8(&dynamic_addr, 1, 0x07, 0x00, false);
+		pec = crc8(&i3c_msg.data[0], i3c_msg.rx_len - 1, 0x07, pec, false);
+		if (pec != i3c_msg.data[i3c_msg.rx_len - 1]) {
+			LOG_ERR("mctp i3c pec error: crc8 should be 0x%02x, but got 0x%02x", pec,
+				i3c_msg.data[i3c_msg.rx_len - 1]);
+			return 0;
+		}
+		/** Remove pec byte if it is valid **/
+		i3c_msg.rx_len--;
+	}
+
+	extra_data->type = MCTP_MEDIUM_TYPE_CONTROLLER_I3C;
+	memcpy(buf, &i3c_msg.data[0], i3c_msg.rx_len);
+	return i3c_msg.rx_len;
+}
+
+static uint16_t mctp_i3c_write(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params extra_data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+
+	if (extra_data.type != MCTP_MEDIUM_TYPE_CONTROLLER_I3C) {
+		LOG_ERR("mctp medium type incorrect");
+		return MCTP_ERROR;
+	}
+
+	int ret;
+	I3C_MSG i3c_msg;
+	mctp *mctp_instance = (mctp *)mctp_p;
+
+	i3c_msg.bus = mctp_instance->medium_conf.i3c_conf.bus;
+	i3c_msg.target_addr = mctp_instance->medium_conf.i3c_conf.addr;
+
+	/** mctp package **/
+	if (len < I3C_MAX_DATA_SIZE) {
+		memcpy(&i3c_msg.data[0], buf, len);
+	} else {
+		LOG_ERR("Write failed because I3C data length exceed %d bytes", I3C_MAX_DATA_SIZE);
+		return MCTP_ERROR;
+	}
+
+	/** +1 pec; default no pec **/
+	if (MCTP_I3C_PEC_ENABLE) {
+		uint8_t pec = 0x0, dynamic_addr = 0x0;
+
+		i3c_msg.tx_len = len + 1;
+		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
+		dynamic_addr = i3c_msg.target_addr << 1;
+		pec = crc8(&dynamic_addr, 1, 0x07, 0x00, false);
+		pec = crc8(&i3c_msg.data[0], len, 0x07, pec, false);
+		i3c_msg.data[len] = pec;
+	} else {
+		i3c_msg.tx_len = len;
+	}
+
+	LOG_HEXDUMP_DBG(&i3c_msg.data[0], i3c_msg.tx_len, "mctp_i3c_write msg dump");
+
+	ret = i3c_controller_write(&i3c_msg);
+	if (ret < 0) {
+		LOG_ERR("i3c controller write failed, %d", ret);
+		return MCTP_ERROR;
+	}
+	return MCTP_SUCCESS;
+}
 
 static uint16_t mctp_i3c_read_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 				  mctp_ext_params *extra_data)
@@ -59,8 +153,8 @@ static uint16_t mctp_i3c_read_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 				i3c_msg.data[i3c_msg.rx_len - 1]);
 			return 0;
 		}
-
-		i3c_msg.rx_len = i3c_msg.rx_len - 1;
+		/** Remove pec byte if it is valid **/
+		i3c_msg.rx_len--;
 	}
 
 	extra_data->type = MCTP_MEDIUM_TYPE_TARGET_I3C;
@@ -104,6 +198,28 @@ static uint16_t mctp_i3c_write_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 	return MCTP_SUCCESS;
 }
 
+uint8_t mctp_i3c_controller_init(mctp *mctp_instance, mctp_medium_conf medium_conf)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_instance, MCTP_ERROR);
+
+	mctp_instance->medium_conf = medium_conf;
+	mctp_instance->read_data = mctp_i3c_read;
+	mctp_instance->write_data = mctp_i3c_write;
+
+	// i3c master initial
+	LOG_INF("Bus= 0x%x, Addr = 0x%x", medium_conf.i3c_conf.bus, medium_conf.i3c_conf.addr);
+	I3C_MSG i3c_msg = { 0 };
+	i3c_msg.bus = medium_conf.i3c_conf.bus;
+	i3c_msg.target_addr = medium_conf.i3c_conf.addr;
+
+	i3c_attach(&i3c_msg);
+
+	// i3c ibi mqueue initial
+	i3c_controller_ibi_init(&i3c_msg);
+
+	return MCTP_SUCCESS;
+}
+
 uint8_t mctp_i3c_target_init(mctp *mctp_instance, mctp_medium_conf medium_conf)
 {
 	CHECK_NULL_ARG_WITH_RETURN(mctp_instance, MCTP_ERROR);
@@ -124,3 +240,5 @@ uint8_t mctp_i3c_deinit(mctp *mctp_instance)
 	memset(&mctp_instance->medium_conf, 0, sizeof(mctp_instance->medium_conf));
 	return MCTP_SUCCESS;
 }
+
+#endif // ENABLE_MCTP_I3C

--- a/meta-facebook/yv35-npcm-test/boards/npcm400f_evb.overlay
+++ b/meta-facebook/yv35-npcm-test/boards/npcm400f_evb.overlay
@@ -43,7 +43,32 @@
 
 &i3c4 {
 	status = "okay";
+	i2c-scl-hz = <100000>;
+	i3c-scl-hz = <12500000>;
 };
+
+/* test for bridge slave mode only, MCTP EID = 0xC
+&i3c4 {
+	status = "okay";
+	bcr = <0x66>;
+	dcr = <0xCC>;
+	part-id = <0x4321>;
+	assigned-address = <0xA>;
+	vendor-def-id = <0x777>;
+	slave;
+	status = "okay";
+	i3c4_smq:i3c-slave-mqueue@A {
+		compatible = "i3c-slave-mqueue";
+		reg = <0xA>;
+		msg-size = <256>;
+		num-of-msgs = <4>;
+		mandatory-data-byte = <0xae>;
+		label = "I3C_SMQ_4";
+		status = "okay";
+	};
+};
+*/
+
 
 &spi_spim0_cs0 {
 	status = "okay";

--- a/meta-facebook/yv35-npcm-test/src/platform/plat_def.h
+++ b/meta-facebook/yv35-npcm-test/src/platform/plat_def.h
@@ -21,5 +21,6 @@
 #define ENABLE_CCI
 #define ENABLE_PM8702
 #define ENABLE_SSIF
+#define ENABLE_MCTP_I3C
 
 #endif

--- a/meta-facebook/yv35-npcm-test/src/platform/plat_mctp.h
+++ b/meta-facebook/yv35-npcm-test/src/platform/plat_mctp.h
@@ -18,36 +18,38 @@
 #define _PLAT_MCTP_h
 
 #include "storage_handler.h"
-#define MCTP_MSG_TYPE_SHIFT 0
-#define MCTP_MSG_TYPE_MASK 0x7F
-#define MCTP_IC_SHIFT 7
-#define MCTP_IC_MASK 0x80
+#define MCTP_MSG_TYPE_SHIFT	0
+#define MCTP_MSG_TYPE_MASK	0x7F
+#define MCTP_IC_SHIFT		7
+#define MCTP_IC_MASK		0x80
 
 /* i2c 8 bit address */
-#define I2C_ADDR_BIC 0x20
-#define I2C_ADDR_CXL0 0x74
-#define I2C_ADDR_CXL1 0xC2
-#define I2C_ADDR_BMC 0x22
+#define I2C_ADDR_BIC		0x20
+#define I2C_ADDR_CXL0		0x74
+#define I2C_ADDR_CXL1		0xC2
+#define I2C_ADDR_BMC		0x22
 /* use i2c0 */
 #define I2C_BUS_PLDM I2C_BUS1
 /* i2c dev bus, use i2c2 */
 #define I2C_BUS_CXL I2C_BUS3
 
 /* mctp endpoint */
-#define CXL_EID 0x2E
-#define BMC_EID 0x15
-#define BIC_EID 0x0A
+#define MCTP_EID_CXL_I2C	0x2E
+#define MCTP_EID_BMC_I2C	0x15
+#define MCTP_EID_BIC_I2C	0x0A
+#define MCTP_EID_BMC_I3C	0x08
+#define MCTP_EID_BIC_I3C	0x0C
 
-/* i3c 8-bit address */
-#define I3C_STATIC_ADDR_BIC	0x21
+/* i3c static 8-bit address */
+#define I3C_STATIC_ADDR_BIC	0xA
 #define I3C_STATIC_ADDR_BMC	0x20
 
-/* i3c dev bus */
-#define I3C_BUS_BMC     5
+/* i3c dynamic 8-bit address */
+#define I3C_DYNAMIC_ADDR_BIC	0xA
 
-/* mctp endpoint */
-#define MCTP_EID_BMC 0x01
-#define MCTP_EID_SELF 0x02
+/* i3c dev bus */
+#define I3C_BUS_MASTER		4
+#define I3C_BUS_BMC		5
 
 /* init the mctp moduel for platform */
 void send_cmd_to_dev(struct k_timer *timer);


### PR DESCRIPTION
support i3c master mode.

BMC(0x8) - i3c0 master (1.8v)
            ^
            |
            v
           i3c5 slave - bridge BIC (0xA) - i3c4 master (3.3v)
                                             ^
                                             |
                                             v
                                           i3c4 slave - slave BIC(0xC)

manual test mctp bios update BIC(0xC) ok

for bridge BIC(0xA):
1. unmask plat_mctp.c MCTP_MEDIUM_TYPE_CONTROLLER_I3C setting. -> enable mctp i3c4 master mode to bridge command to slave BIC.

for slave BIC(0xC):
1. unmask dts overlay i3c4 to slave mode. -> enable i3c4 smq
2. change MCTP default EID = 0x0C (in mctp.h) -> change default EID to 0xc
3. change I3C_BUS_BMC to 4 (in plat_mctp.h) -> transfer and received mctp packet from i3c4